### PR TITLE
Use SourceIdentity as a default for RoleSessionName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 `aws-assume-role-lib` uses [monotonic versioning](http://blog.appliedcompscilab.com/monotonic_versioning_manifesto/).
 
+## NEXT
+* Fixed `get_assumed_role_session_arn()`, which incorrectly used `iam` instead of `sts` in the ARN.
+* If `RoleSessionName` is not provided but `SourceIdentity` is, the `SourceIdentity` value will be used for `RoleSessionName`, rather than the `botocore`-generated value.
+    * Added special value `AUTOMATIC_ROLE_SESSION_NAME`; setting `RoleSessionName` to this will cause it to use pre-2.8 behavior (i.e., always use `botocore`-generated value).
+
 ## v2.8
 * If `region_name=None` (the default), the child session region is linked to the parent session region (not copied, which happens if `region_name=True`). If the parent session is using a config profile, this means the child session will have a region, rather than needing/using a separately-set region (e.g., via the `AWS_DEFAULT_REGION` environment variable). For safety, this release increments the [compatibility version](http://blog.appliedcompscilab.com/monotonic_versioning_manifesto/) to 2.
 * Added [command line functionality](README.md#command-line-use).

--- a/tests/template.yaml
+++ b/tests/template.yaml
@@ -12,7 +12,9 @@ Resources:
         Version: 2012-10-17
         Statement:
           Effect: Allow
-          Action: sts:AssumeRole
+          Action:
+          - sts:AssumeRole
+          - sts:SetSourceIdentity
           Principal:
             "AWS": !Ref AWS::AccountId
       Policies:


### PR DESCRIPTION
* Fixed `get_assumed_role_session_arn()`, which incorrectly used `iam` instead of `sts` in the ARN.
* If `RoleSessionName` is not provided but `SourceIdentity` is, the `SourceIdentity` value will be used for `RoleSessionName`, rather than the `botocore`-generated value.
    * Added special value `AUTOMATIC_ROLE_SESSION_NAME`; setting `RoleSessionName` to this will cause it to use pre-2.8 behavior (i.e., always use `botocore`-generated value).